### PR TITLE
Add dependencies to Maven pom.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ For more info/documentation, please check [SugarOnRest wiki](https://github.com/
 
 ### Basic Sample Usages
 ```java
-string sugarCrmUrl = "http://demo.suiteondemand.com/service/v4_1/rest.php";
-string sugarCrmUsername = "will";
-string sugarCrmPassword = "will";
+String sugarCrmUrl = "http://demo.suiteondemand.com/service/v4_1/rest.php";
+String sugarCrmUsername = "will";
+String sugarCrmPassword = "will";
 
 SugarRestClient client = new SugarRestClient(sugarCrmUrl, sugarCrmUsername, sugarCrmPassword);
 
@@ -26,7 +26,7 @@ Accounts account = (Accounts)accountResponse.getData();
 
 // Option 2 - Read by known SugarCRM module name - "Contacts".
 SugarRestRequest contactRequest = new SugarRestRequest("Contacts", RequestType.ReadById);
-contactRequest.setParameter(contactid);
+contactRequest.setParameter("1b680648-20ca-cd20-692e-584fbec623e5");
 SugarRestResponse contactRresponse = client.execute(contactRequest);
 Contacts contact = (Contacts)contactRresponse.getData();
 

--- a/sugaronrest/pom.xml
+++ b/sugaronrest/pom.xml
@@ -28,5 +28,10 @@
 			<artifactId>unirest-java</artifactId>
 			<version>1.4.9</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/sugaronrest/pom.xml
+++ b/sugaronrest/pom.xml
@@ -1,12 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.sugaronrest</groupId>
-    <artifactId>sugaronrest</artifactId>
-    <version>1.0.0</version>
+	<groupId>com.sugaronrest</groupId>
+	<artifactId>sugaronrest</artifactId>
+	<version>1.0.0</version>
 
-
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.8.8</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.mashape.unirest</groupId>
+			<artifactId>unirest-java</artifactId>
+			<version>1.4.9</version>
+		</dependency>
+	</dependencies>
 </project>


### PR DESCRIPTION
The pom.xml is missing the required dependencies for compiling.
There seem to be another build problem related to the file names, e.g.:
"Sugarfeed.java:[33,8] class SugarFeed is public, should be declared in a file named SugarFeed.java"

Will deal with this in another commit (might need to change the original file that generates those classes).